### PR TITLE
Bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.2
+current_version = 1.6.3
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,9 @@
+[bumpversion]
+current_version = 1.6.2
+commit = True
+tag = True
+tag_name = {new_version}
+
+[bumpversion:file:pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,12 @@ pre-commit install
 
 ## Publishing to PyPi
 
-Bump the version according to semantic versioning locally on branch `master` using poetry:
+Bump the version according to semantic versioning locally on branch `master` using [bumpversion]:
 
 ```
-poetry version [major | minor | patch ]
+bumpversion [major | minor | patch ]
+git push
+git push --tag
 ```
 
 Reinstall the application with the new version:
@@ -35,5 +37,6 @@ poetry publish
 ```
 
 [black-url]: https://github.com/psf/black
+[bumpversion]: https://github.com/c4urself/bump2version
 [development-branch-model]: http://www.clinicalgenomics.se/development/dev/models/
 [semantic versioning]: https://semver.org/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "varg"
-version = "1.6.2"
+version = "1.6.3"
 description = "Benchmark vcf-files against a truth-set of positive controls"
 authors = ["henrikstranneheim <henrik.stranneheim@scilifelab.se>"]
 license = "MIT"


### PR DESCRIPTION
### This PR adds | fixes:
- Adds a bumpversion2 config and use it to bumpversion for poetry toml project file
- This will also create tags and versions

### How to test:
- Bumperversion pathc

### Expected outcome:
- Poetry toml project file version was incremented

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
